### PR TITLE
feat(web): add QOJ member provider import support

### DIFF
--- a/web/src/lib/qoj.ts
+++ b/web/src/lib/qoj.ts
@@ -1,0 +1,148 @@
+import type {
+  LocalCatalogProblemRecord,
+  LocalImportSourceRecord,
+  LocalMemberHandleRecord,
+  LocalMemberProblemStatusRecord,
+  LocalMemberRecord,
+  LocalSyncRecord,
+} from "./local-model";
+import { listCatalogProblemsFromDb, upsertMemberBundle } from "./local-db";
+
+export type QojImportSummary = {
+  memberId: string;
+  handle: string;
+  matchedStatusCount: number;
+  unresolvedStatusCount: number;
+  solvedCount: number;
+  attemptedCount: number;
+};
+
+function normalizeProblemIdTokens(value: string[]) {
+  return [...new Set(value.map((item) => item.trim()).filter((item) => item.length > 0))];
+}
+
+function findProblemByQojProviderProblemId(
+  catalogProblems: LocalCatalogProblemRecord[],
+  providerProblemId: string,
+): LocalCatalogProblemRecord | undefined {
+  return catalogProblems.find((problem) =>
+    problem.sources.some((source) => source.provider === "qoj" && source.provider_problem_id === providerProblemId),
+  );
+}
+
+export async function importQojMember(payload: {
+  memberId: string;
+  handle: string;
+  solvedProblemIds: string[];
+  attemptedProblemIds: string[];
+  displayName?: string;
+  exportedAt?: string;
+}): Promise<QojImportSummary> {
+  const startedAt = new Date().toISOString();
+  const importedAt = new Date().toISOString();
+  const sourceRecordId = `qoj:${payload.handle}:${importedAt}`;
+
+  const solvedIds = normalizeProblemIdTokens(payload.solvedProblemIds);
+  const attemptedIds = normalizeProblemIdTokens(payload.attemptedProblemIds);
+  const statusByProviderProblemId = new Map<string, "solved" | "attempted">();
+
+  for (const providerProblemId of attemptedIds) {
+    statusByProviderProblemId.set(providerProblemId, "attempted");
+  }
+  for (const providerProblemId of solvedIds) {
+    statusByProviderProblemId.set(providerProblemId, "solved");
+  }
+
+  const catalogProblems = await listCatalogProblemsFromDb();
+  const statuses: LocalMemberProblemStatusRecord[] = [];
+  const unresolvedProviderProblemIds: string[] = [];
+
+  for (const [providerProblemId, status] of statusByProviderProblemId.entries()) {
+    const matchedProblem = findProblemByQojProviderProblemId(catalogProblems, providerProblemId);
+    if (!matchedProblem) {
+      unresolvedProviderProblemIds.push(providerProblemId);
+      continue;
+    }
+    statuses.push({
+      statusId: `${payload.memberId}:${matchedProblem.problemId}:qoj`,
+      memberId: payload.memberId,
+      problemId: matchedProblem.problemId,
+      provider: "qoj",
+      status,
+      firstSeenAt: importedAt,
+      lastSeenAt: importedAt,
+      sourceRecordId,
+      matchMethod: "provider_id",
+    });
+  }
+
+  const member: LocalMemberRecord = {
+    memberId: payload.memberId,
+    displayName: payload.displayName?.trim() || payload.memberId,
+    createdAt: importedAt,
+    updatedAt: importedAt,
+  };
+
+  const handles: LocalMemberHandleRecord[] = [
+    {
+      handleId: `qoj:${payload.handle}`,
+      memberId: payload.memberId,
+      provider: "qoj",
+      handle: payload.handle,
+      displayLabel: payload.displayName?.trim() || null,
+      createdAt: importedAt,
+      updatedAt: importedAt,
+    },
+  ];
+
+  const importSource: LocalImportSourceRecord = {
+    sourceRecordId,
+    kind: "qoj_userscript_json",
+    label: `QOJ userscript import for ${payload.handle}`,
+    importedAt,
+    rawMetaJson: {
+      handle: payload.handle,
+      exported_at: payload.exportedAt ?? null,
+      solved_count: solvedIds.length,
+      attempted_count: attemptedIds.length,
+      normalized_problem_status_count: statusByProviderProblemId.size,
+      matched_status_count: statuses.length,
+      unresolved_status_count: unresolvedProviderProblemIds.length,
+      unresolved_provider_problem_ids: unresolvedProviderProblemIds.slice(0, 200),
+    },
+  };
+
+  const syncRecord: LocalSyncRecord = {
+    syncId: `qoj-sync:${payload.handle}:${importedAt}`,
+    sourceRecordId,
+    adapter: "qoj_userscript",
+    startedAt,
+    finishedAt: importedAt,
+    status: "succeeded",
+    summaryJson: {
+      handle: payload.handle,
+      solved_count: solvedIds.length,
+      attempted_count: attemptedIds.length,
+      normalized_problem_status_count: statusByProviderProblemId.size,
+      matched_status_count: statuses.length,
+      unresolved_status_count: unresolvedProviderProblemIds.length,
+    },
+  };
+
+  await upsertMemberBundle({
+    member,
+    handles,
+    statuses,
+    importSource,
+    syncRecord,
+  });
+
+  return {
+    memberId: payload.memberId,
+    handle: payload.handle,
+    matchedStatusCount: statuses.length,
+    unresolvedStatusCount: unresolvedProviderProblemIds.length,
+    solvedCount: solvedIds.length,
+    attemptedCount: attemptedIds.length,
+  };
+}

--- a/web/src/views/AddMemberView.vue
+++ b/web/src/views/AddMemberView.vue
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router";
 
 import { importCodeforcesMember } from "../lib/codeforces";
 import { emitMemberMutated } from "../lib/member-events";
+import { importQojMember } from "../lib/qoj";
 
 const router = useRouter();
 const submitting = ref(false);
@@ -11,14 +12,24 @@ const error = ref("");
 const feedback = ref("");
 
 const memberForm = ref({
+  provider: "codeforces" as "codeforces" | "qoj",
   memberId: "",
   providerHandle: "",
   displayName: "",
+  qojSolvedIds: "",
+  qojAttemptedIds: "",
 });
 
-async function submitCodeforcesImport() {
+function splitProblemIds(raw: string) {
+  return raw
+    .split(/[\s,\n\r\t]+/g)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+}
+
+async function submitMemberImport() {
   if (!memberForm.value.memberId.trim() || !memberForm.value.providerHandle.trim()) {
-    error.value = "member id and Codeforces handle are required";
+    error.value = "member id and handle are required";
     return;
   }
 
@@ -26,15 +37,25 @@ async function submitCodeforcesImport() {
   error.value = "";
   feedback.value = "";
   try {
-    await importCodeforcesMember({
-      memberId: memberForm.value.memberId.trim(),
-      handle: memberForm.value.providerHandle.trim(),
-      displayName: memberForm.value.displayName.trim() || undefined,
-    });
+    if (memberForm.value.provider === "codeforces") {
+      await importCodeforcesMember({
+        memberId: memberForm.value.memberId.trim(),
+        handle: memberForm.value.providerHandle.trim(),
+        displayName: memberForm.value.displayName.trim() || undefined,
+      });
+    } else {
+      await importQojMember({
+        memberId: memberForm.value.memberId.trim(),
+        handle: memberForm.value.providerHandle.trim(),
+        displayName: memberForm.value.displayName.trim() || undefined,
+        solvedProblemIds: splitProblemIds(memberForm.value.qojSolvedIds),
+        attemptedProblemIds: splitProblemIds(memberForm.value.qojAttemptedIds),
+      });
+    }
     emitMemberMutated();
     await router.replace({ name: "members" });
   } catch (caught) {
-    error.value = caught instanceof Error ? caught.message : "failed to import Codeforces member";
+    error.value = caught instanceof Error ? caught.message : "failed to import member";
   } finally {
     submitting.value = false;
   }
@@ -47,29 +68,50 @@ async function submitCodeforcesImport() {
       <div class="panel__body">
         <div class="panel__header">
           <div class="panel__title">
-            <p class="eyebrow">Codeforces</p>
+            <p class="eyebrow">Member Import</p>
             <h2>Add Member</h2>
           </div>
         </div>
 
         <div class="form-grid">
           <div class="field">
+            <label for="add-member-provider">Provider</label>
+            <select id="add-member-provider" v-model="memberForm.provider" class="input-select">
+              <option value="codeforces">Codeforces API</option>
+              <option value="qoj">QOJ userscript snapshot</option>
+            </select>
+          </div>
+          <div class="field">
             <label for="add-member-id">成员名</label>
             <input id="add-member-id" v-model="memberForm.memberId" placeholder="alice" />
           </div>
           <div class="field">
-            <label for="add-member-handle">Codeforces 账户名</label>
-            <input id="add-member-handle" v-model="memberForm.providerHandle" placeholder="tourist" />
+            <label for="add-member-handle">
+              {{ memberForm.provider === "codeforces" ? "Codeforces 账户名" : "QOJ 账户名" }}
+            </label>
+            <input
+              id="add-member-handle"
+              v-model="memberForm.providerHandle"
+              :placeholder="memberForm.provider === 'codeforces' ? 'tourist' : 'Rainybunny'"
+            />
           </div>
           <div class="field">
             <label for="add-member-name">显示名称（可选）</label>
             <input id="add-member-name" v-model="memberForm.displayName" placeholder="Alice" />
           </div>
+          <div v-if="memberForm.provider === 'qoj'" class="field">
+            <label for="add-member-qoj-solved">QOJ AC 题号（空格/逗号分隔）</label>
+            <textarea id="add-member-qoj-solved" v-model="memberForm.qojSolvedIds" rows="4" placeholder="1001, 1002, 1003" />
+          </div>
+          <div v-if="memberForm.provider === 'qoj'" class="field">
+            <label for="add-member-qoj-attempted">QOJ 尝试过题号（空格/逗号分隔）</label>
+            <textarea id="add-member-qoj-attempted" v-model="memberForm.qojAttemptedIds" rows="4" placeholder="1004, 1005" />
+          </div>
         </div>
 
         <div class="actions">
-          <button class="button" :disabled="submitting" @click="submitCodeforcesImport">
-            {{ submitting ? "导入中..." : "导入 Codeforces 成员" }}
+          <button class="button" :disabled="submitting" @click="submitMemberImport">
+            {{ submitting ? "导入中..." : (memberForm.provider === "codeforces" ? "导入 Codeforces 成员" : "导入 QOJ 成员快照") }}
           </button>
         </div>
 


### PR DESCRIPTION
### Motivation
- Add a QOJ userscript-style import adapter so the tracker can ingest QOJ AC/attempted snapshots in the browser without server scraping, matching the frontend-first import contract.
- Preserve unresolved provider problem ids and import provenance so curator review and deterministic matching follow the established import rules.

### Description
- Add `web/src/lib/qoj.ts` with `importQojMember` which normalizes deduplicated solved/attempted IDs, prefers `solved` when both appear, maps entries by `qoj` `provider_problem_id` to curated catalog problems, and writes member/handle/status/import/sync provenance via `upsertMemberBundle`.
- Unmatched QOJ problem ids are preserved in import metadata (`rawMetaJson`) and counted in sync summaries rather than being silently dropped.
- Update `web/src/views/AddMemberView.vue` to introduce a provider selector (`codeforces` | `qoj`) and provider-specific inputs, and route imports to `importCodeforcesMember` or `importQojMember` with simple token parsing for QOJ problem-id lists.
- Keep existing Codeforces import flow and data model unchanged while reusing the same `Local*` types and IndexedDB upsert path.

### Testing
- Ran a production build with TypeScript checks using `cd web && npm run build`, which completed successfully (vite build + `vue-tsc` passed).
- No network-dependent or browser automation tests were run; local build is the primary automated validation for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61b4c45a48323a5a2e5035192edb3)